### PR TITLE
Fix a bug in getting the current DJ name

### DIFF
--- a/scripts/content/JukeBot.js
+++ b/scripts/content/JukeBot.js
@@ -199,7 +199,7 @@ function JukeBot() {
 		var split = djElement.href.split(':');
 		var spotifyName = split[split.length - 1];
 		
-		var jqbxName = djElement.children[1].innerHTML;
+		var jqbxName = djElement.children[0].children[1].innerHTML;
 		
 		return {
 			spotifyName: spotifyName,


### PR DESCRIPTION
JQBX seems to have added a contextmenu-wrapper, so in order to access the DJ name you have to dig one layer deeper