### PR TITLE
Add keyboard shortcuts for main actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 A handy chrome extension for http://jqbx.fm/.
 
 
-Save the app or extension folder on your test device, either via git clone or clicking the green Code button on this page and downloading the zip, then unzipping. 
-Go to chrome://extensions/.
-At the top right, turn on Developer mode.
-Click Load unpacked.
-Find and select the extension folder.
-Go back to JQBX and refresh the page.
+1. Save the app or extension folder on your test device, either via git clone or clicking the green Code button on this page and downloading the zip, then unzipping. 
+1. Go to chrome://extensions/.
+1. At the top right, turn on Developer mode.
+1. Click Load unpacked.
+1. Find and select the extension folder.
+1. Go back to JQBX and refresh the page.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # JukeBot
 A handy chrome extension for http://jqbx.fm/.
+
+
+Save the app or extension folder on your test device, either via git clone or clicking the green Code button on this page and downloading the zip, then unzipping. 
+Go to chrome://extensions/.
+At the top right, turn on Developer mode.
+Click Load unpacked.
+Find and select the extension folder.
+Go back to JQBX and refresh the page.

--- a/manifest.json
+++ b/manifest.json
@@ -36,8 +36,40 @@
                 "./scripts/content/plugins/SongWatcher.js",
                 "./scripts/content/plugins/VoteWatcher.js",
                 "./scripts/content/plugins/AutoDoot.js",
-                "./scripts/content/plugins/Notifier.js"
+                "./scripts/content/plugins/Notifier.js",
+                "./scripts/content/plugins/ShortcutHandler.js"
+                
             ]
         }
-    ]
+    ],
+    "commands": {
+          "dope": {
+            "suggested_key": {
+              "default": "Ctrl+Shift+Y",
+              "mac": "Command+Shift+Y"
+            },
+            "description": "Dope"
+          },
+          "stepupdown": {
+            "suggested_key": {
+              "default": "Ctrl+Shift+U",
+              "mac": "Command+Shift+U"
+            },
+            "description": "Toggle DJ Status"
+          },
+          "star": {
+            "suggested_key": {
+              "default": "Ctrl+Shift+H",
+              "mac": "Command+Shift+H"
+            },
+            "description": "Star"
+          },
+          "syncaudio": {
+            "suggested_key": {
+              "default": "Ctrl+Shift+K",
+              "mac": "Command+Shift+K"
+            },
+            "description": "Sync Audio"
+          }
+        }
 }

--- a/popup.html
+++ b/popup.html
@@ -39,16 +39,6 @@
     <table class="script-list">
       <tr>
         <td>
-          <span class="script-title started">JukeBot</span>
-        </td>
-        <td>
-          Main script for JukeBot. Allows you to do things like view the song that is currently playing or give a quick thumbs-up.
-        </td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>
           <span id="auto-doot-title" class="script-title">AutoDope</span>
         </td>
         <td>
@@ -102,7 +92,7 @@
     </div>
 
     <div id="created-by">
-      <i>Created by Hawk</i>
+      <i>Created by Hawk, patched by Darin</i>
     </div>
   </body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -39,10 +39,15 @@
     <table class="script-list">
       <tr>
         <td>
-          <span id="auto-doot-title" class="script-title">AutoDope</span>
+          <span id="auto-doot-title" class="script-title">Auto Vote</span>
         </td>
         <td>
-          Spread the love! Automatically give a thumbs-up for every song.
+          <label for="voteType">Automatically vote for every song: </label>
+          <select name="voteType" id="voteType">
+            <option value="upvote">Upvote</option>
+            <option value="boofstar">Boofstar</option>
+            <option value="downvote">Downvote :(</option>
+          </select>
         </td>
         <td></td>
         <td>

--- a/scripts/background/background.js
+++ b/scripts/background/background.js
@@ -30,7 +30,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
                         message: request.data.message.text,
                         title: isAlert ? "(Alert)" : request.data.message.author
                     };
-                    chrome.notifications.create('jukebot_notif', notificationObject);
+                    createNotification(request.data.message.text, (isAlert ? "(Alert)" : request.data.message.author));
                 }
             }
         });

--- a/scripts/background/background.js
+++ b/scripts/background/background.js
@@ -1,4 +1,5 @@
 var notifierOptionsVisible = false;
+var starred = false;
 
 var defaultValues = [
     { key: 'autoDootEnabled', value: false },
@@ -35,3 +36,58 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         });
     }
 });
+
+function sendMessage(event, data, callback) {
+    chrome.tabs.query({url: '*://app.jqbx.fm/*', currentWindow: true}, function (tabs) {
+        if (tabs.length > 0) {
+            chrome.tabs.sendMessage(tabs[0].id, {
+                event: event,
+                data: data
+            }, callback);
+        }
+    });
+}
+
+chrome.commands.onCommand.addListener(function(command) {
+    switch (command) {
+        case "dope": sendDope(); break;
+        case "stepupdown": sendStepUpDown(); break;
+        case "star": sendStar(); break;
+        case "syncaudio": sendSyncAudio(); break;
+    }
+
+  });
+
+function sendDope() {
+    createNotification('You upvoted the current track!',"JQBX Notification");    
+    sendMessage('upvote-shortcut', {});
+    return;
+}
+
+function sendStepUpDown() {
+    createNotification("Toggled DJ'ing!","JQBX Notification");    
+    sendMessage('stepupdown-shortcut', {});
+    return;
+}
+
+function sendStar() {
+    createNotification('You toggled the star on the current track!',"JQBX Notification");
+    sendMessage('star-shortcut', {});
+    return;
+}
+
+function sendSyncAudio() {
+    createNotification('Audio synced!',"JQBX Notification");    
+    sendMessage('syncaudio-shortcut', {});
+    return;
+}
+
+function createNotification(message, title) {
+    var notificationObject = {
+        type: 'basic',
+        iconUrl: './icons/icon48.png',
+        message: message,
+        title: title
+    };
+    chrome.notifications.create('jukebot_notif', notificationObject);
+}

--- a/scripts/content/JukeBot.js
+++ b/scripts/content/JukeBot.js
@@ -285,7 +285,7 @@ function JukeBot() {
 	}
 
 	function getRoomName() {
-		var titleElement = document.querySelector('.header .title > span');
+		var titleElement = document.querySelector('.header .title a');
 
 		if (!titleElement) {
 			return null;
@@ -347,6 +347,25 @@ function JukeBot() {
 	this.downvote = function () {
 		sendVote(false);
 	};
+
+	this.stepUpDown = function() {
+		var stepDownElement = document.querySelector('button.step-down');
+		var stepUpElement = document.querySelector('button.step-up');
+		stepDownElement ? stepDownElement.click() : (stepUpElement ? stepUpElement.click() : null);
+	};
+
+	this.syncAudio = function() {
+		var syncAudioElement = document.querySelector('button.sync');
+		var resumeAudioElement = document.querySelector('button.resume');
+		syncAudioElement ? syncAudioElement.click() : (resumeAudioElement ? resumeAudioElement.click() : null);
+	}
+
+	this.star = function() {
+		var starElement = document.querySelector('button.star');
+		if (starElement) {
+			starElement.click();
+		}
+	}
 	
 	this.addHandler = function (id, eventType, callback) {
 		if (!this.events[eventType]) {
@@ -385,6 +404,8 @@ function JukeBot() {
 
 		return false;
 	};
+
+
 	
 	this.start = function () {
 		updateInterval = setInterval(function () {
@@ -409,4 +430,5 @@ function JukeBot() {
 	this.stop = function () {
 		clearInterval(updateInterval);
 	};
+
 };

--- a/scripts/content/content.js
+++ b/scripts/content/content.js
@@ -4,6 +4,7 @@ window.onload = function () {
     var voteWatcher = new VoteWatcher(jukeBot);
     var autoDoot = new AutoDoot(jukeBot);
     var notifier = new Notifier(jukeBot);
+    var shortcutHandler = new ShortcutHandler(jukeBot);
 
     chrome.storage.sync.get('autoDootEnabled', function (response) {
         if (response.autoDootEnabled != null) {

--- a/scripts/content/content.js
+++ b/scripts/content/content.js
@@ -13,6 +13,14 @@ window.onload = function () {
             }
         }
     });
+
+    chrome.storage.sync.get('autoDootType', function (response) {
+        if (response.autoDootType != null) {
+            if (response.autoDootEnabled) {
+                autoDoot.start();
+            }
+        }
+    });
     
     chrome.storage.sync.get('notifierEnabled', function (response) {
         if (response.notifierEnabled != null) {

--- a/scripts/content/plugins/AutoDoot.js
+++ b/scripts/content/plugins/AutoDoot.js
@@ -4,29 +4,52 @@ function AutoDoot(jukeBot) {
     var self = this;
 
     chrome.storage.sync.get('autoDootEnabled', function (response) {
-        if (response.autoDootEnabled != null && response.autoDootEnabled == true) {
-            self.start();
-        }
+        chrome.storage.sync.get('autoDootType', function (typeResponse) {
+            if (response.autoDootEnabled != null && response.autoDootEnabled == true) {
+                self.start(typeResponse.autoDootType);
+            }
+        });
     });
 
     chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-        if (request.event == 'auto_doot_toggled') {
+        if (request.event == 'auto_doot_toggled' || request.event == 'auto_doot_type_changed') {
             if (request.data.enabled) {
-                self.start();
+                self.start(request.data.type);
             } else {
                 self.stop();
             }
         }
     });
 
-    this.start = function () {
-        if (!running) {
-            jukeBot.upvote();
-            jukeBot.addHandler(handlerId, jukeBot.events.songChanged, function () {
-                setTimeout(function() {
-                    jukeBot.upvote();
-                }, 2500);
-            });
+    this.start = function (type) {
+        if (!running && type) {
+            if (type == "upvote") {
+                jukeBot.upvote();
+                jukeBot.addHandler(handlerId, jukeBot.events.songChanged, function () {
+                    setTimeout(function() {
+                        jukeBot.upvote();
+                    }, 2500);
+                });
+            }
+            else if (type == "boofstar") {
+                jukeBot.downvote();
+                jukeBot.star();
+                jukeBot.addHandler(handlerId, jukeBot.events.songChanged, function () {
+                    setTimeout(function() {
+                        jukeBot.downvote();
+                        jukeBot.star();
+                    }, 2500);
+                });
+            }
+            else if (type == "downvote") {
+                jukeBot.downvote();
+                jukeBot.addHandler(handlerId, jukeBot.events.songChanged, function () {
+                    setTimeout(function() {
+                        jukeBot.upvote();
+                    }, 2500);
+                });
+            }
+
             running = true;
         }
     };

--- a/scripts/content/plugins/AutoDoot.js
+++ b/scripts/content/plugins/AutoDoot.js
@@ -12,11 +12,17 @@ function AutoDoot(jukeBot) {
     });
 
     chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-        if (request.event == 'auto_doot_toggled' || request.event == 'auto_doot_type_changed') {
+        if (request.event == 'auto_doot_toggled') {
             if (request.data.enabled) {
                 self.start(request.data.type);
             } else {
                 self.stop();
+            }
+        }
+        else if (request.event == 'auto_doot_type_changed') {
+            if (request.data.enabled) {
+                self.stop();
+                self.start(request.data.type);
             }
         }
     });
@@ -45,7 +51,7 @@ function AutoDoot(jukeBot) {
                 jukeBot.downvote();
                 jukeBot.addHandler(handlerId, jukeBot.events.songChanged, function () {
                     setTimeout(function() {
-                        jukeBot.upvote();
+                        jukeBot.downvote();
                     }, 2500);
                 });
             }

--- a/scripts/content/plugins/ShortcutHandler.js
+++ b/scripts/content/plugins/ShortcutHandler.js
@@ -1,0 +1,18 @@
+function ShortcutHandler(jukeBot) {
+    const handlerId = 'shortcutHandler';
+
+    chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+        if (request.event == 'upvote-shortcut') {
+            jukeBot.upvote();
+        }   
+        if (request.event == 'stepupdown-shortcut') {
+            jukeBot.stepUpDown();
+        }
+        if (request.event == 'star-shortcut') {
+            jukeBot.star();
+        }
+        if (request.event == 'syncaudio-shortcut') {
+            jukeBot.syncAudio();
+        }
+    });
+}

--- a/scripts/popup/popup.js
+++ b/scripts/popup/popup.js
@@ -3,12 +3,21 @@ var progressInterval;
 var animator;
 
 var autoDootEnabled;
+var autoDootType = "upvote";
 var notifierEnabled;
 
 window.onload = function () {
     animator = new Animator();
     pageElements = findElements();
     initHandlers();
+
+    chrome.storage.sync.get('autoDootType', function (response) {
+        autoDootType = response.autoDootType;
+        var els = document.querySelector(`select[name="voteType"] option[value="${autoDootType}"]`);
+        if(els){
+            els.selected = true;
+        }
+    });
 
     chrome.storage.sync.get('autoDootEnabled', function (response) {
         autoDootEnabled = response.autoDootEnabled;
@@ -65,6 +74,7 @@ function findElements() {
         progressFill: document.getElementById('progress-fill'),
         autoDootTitle: document.getElementById('auto-doot-title'),
         autoDootCheckbox: document.getElementById('auto-doot-checkbox'),
+        autoDootType: document.getElementById('voteType'),
         notifierTitle: document.getElementById('notifier-title'),
         notifierCheckbox: document.getElementById('notifier-checkbox'),
         notifierShowAllCheckbox: document.getElementById('notifier-show-all'),
@@ -100,7 +110,14 @@ function initHandlers() {
             autoDootEnabled = !autoDootEnabled;
             animator.toggleClass(pageElements.autoDootTitle, 'started', autoDootEnabled);
             self.checked = !self.checked;
-            sendMessage('auto_doot_toggled', {enabled: autoDootEnabled});
+            sendMessage('auto_doot_toggled', {enabled: autoDootEnabled, type: autoDootType});
+        });
+    };
+
+    pageElements.autoDootType.onchange = function () {
+        chrome.storage.sync.set({'autoDootType': pageElements.autoDootType.value}, function () {
+            autoDootType = pageElements.autoDootType.value;
+            sendMessage('auto_doot_type_changed', {enabled: autoDootEnabled, type: autoDootType});
         });
     };
 


### PR DESCRIPTION
Using Chrome's built in keyboard [shortcut manager for extensions](chrome://extensions/shortcuts), this will add customize-able keyboard shortcuts for Dope, Become a DJ/Step Down, Star, and Sync Audio. 

Unfortunately, Chrome limits extensions to four keyboard shortcuts. 